### PR TITLE
Duplication fix

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -347,7 +347,7 @@ AddEventHandler('esx_property:putItem', function(owner, type, item, count)
 
     local playerItemCount = xPlayer.getInventoryItem(item).count
 
-    if playerItemCount >= count then
+    if playerItemCount >= count and count > 0 then
      
       TriggerEvent('esx_addoninventory:getInventory', 'property', xPlayerOwner.identifier, function(inventory)
         xPlayer.removeInventoryItem(item, count)
@@ -365,7 +365,7 @@ AddEventHandler('esx_property:putItem', function(owner, type, item, count)
 
     local playerAccountMoney = xPlayer.getAccount(item).money
 
-    if playerAccountMoney >= count then
+    if playerAccountMoney >= count and count > 0 then
 
       xPlayer.removeAccountMoney(item, count)
 


### PR DESCRIPTION
Simply fixed is so that it prevents players from storing items in a negative amount. Storing a certain item as -1 and go to take it out and place whatever amount you want and boom you got unlimited amount of said item.